### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 authors = ["@gaker"]
 license = "MIT OR Apache-2.0"
 
-repository = "https://www.github.com/gaker/astro-math"
+repository = "https://github.com/gaker/astro-math"
 readme = "README.md"
 description = "Astronomy math algorithms for telescope control and sky transforms"
 keywords = ["astronomy", "astrometry", "sidereal", "astrophysics", "coordinates"]


### PR DESCRIPTION
Github redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96
